### PR TITLE
lf eol convert fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "format": "prettier --write .",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
Changes: Changed crlf to lf for end of line format since it's was causing issues with windows vscode and vercel is linux/unix based